### PR TITLE
Ensure there is no fallback for Buffer, util, or crypto.

### DIFF
--- a/test/karma.conf.cjs
+++ b/test/karma.conf.cjs
@@ -54,7 +54,14 @@ module.exports = function(config) {
 
     webpack: {
       devtool: 'inline-source-map',
-      mode: 'development'
+      mode: 'development',
+      resolve: {
+        fallback: {
+          buffer: false,
+          util: false,
+          crypto: false
+        }
+      }
     }
   });
 };


### PR DESCRIPTION
Adds resolve.fallback. node stuff = false to ensure karma doesn't have polyfills for crypto or buffer.